### PR TITLE
Feature/support command result remote save

### DIFF
--- a/Open_LISA_SDK/__init__.py
+++ b/Open_LISA_SDK/__init__.py
@@ -158,16 +158,16 @@ class SDK:
             print(e)
             return False
 
-    def send_command(self, instrument_id, command_invocation, response_format=None, convert_result_to=None):
+    def send_command(self, instrument_id, command_invocation, command_result_output_file=None, response_format=None, convert_result_to=None):
         if response_format == SDK_RESPONSE_FORMAT_JSON or (
                 response_format == None and self._default_response_format == SDK_RESPONSE_FORMAT_JSON):
             # If response format is json convert_result_to is ignored
-            return self._client_protocol.send_command_and_result_as_json_string(instrument_id, command_invocation)
+            return self._client_protocol.send_command_and_result_as_json_string(instrument_id, command_invocation, command_result_output_file)
 
         command_execution_result = self._client_protocol.send_command(
-            instrument_id, command_invocation)
+            instrument_id, command_invocation, command_result_output_file)
 
-        if not convert_result_to:
+        if not convert_result_to or command_result_output_file:
             return command_execution_result
 
         original_value = command_execution_result["value"]


### PR DESCRIPTION
Se agrega soporte para guardar el valor resultante de la ejecución de un comando en el servidor. Para ello se hace un breaking change en lo que respecta `send_command` para la comunicación cliente-servidor

Anteriormente se enviaban dos mensajes:
* instrument ID
* invocación del comando en sí

Ahora se envía un **único** mensaje en formato JSON con la siguiente estructura:
```json
{
            "instrument_id": string,
            "command_invocation": string,
            "command_result_output_file": [string]/null
}
```