### PR TITLE
fix send command and add test

### DIFF
--- a/Open_LISA_SDK/domain/protocol/client_protocol.py
+++ b/Open_LISA_SDK/domain/protocol/client_protocol.py
@@ -175,6 +175,9 @@ class ClientProtocol:
         json_str = self.send_command_and_result_as_json_string(
             id, command, command_result_output_file)
 
+        if not json_str and command_result_output_file:
+            return None
+
         command_execution_result_dict = json.loads(json_str)
         command_execution_value = command_execution_result_dict["value"]
         command_execution_type = command_execution_result_dict["type"]
@@ -201,7 +204,9 @@ class ClientProtocol:
         self._message_protocol.send_msg(json.dumps(command_execution_request))
         response_type = self._message_protocol.receive_msg()
         if self.__is_valid_response(response_type):
-            command_execution_result_json_str = self._message_protocol.receive_msg()
+            command_execution_result_json_str = None
+            if not command_result_output_file: # if result was saved in Server this message is not sent
+                command_execution_result_json_str = self._message_protocol.receive_msg()
             te = time()
             log.debug("[LATENCY_MEASURE][FINISH][{}][command={}][ELAPSED={} seconds]".format(
                 'send_command', command, te-ts))

--- a/Open_LISA_SDK/tests/test_integration_with_server.py
+++ b/Open_LISA_SDK/tests/test_integration_with_server.py
@@ -151,7 +151,6 @@ def test_send_command_and_save_result_in_server():
     result = sdk.send_command(instrument_id=MOCK_CAMERA_ID,
                               command_invocation="get_image", command_result_output_file="sandbox/output.jpg")
     assert result == None
-    sdk.get_directory_structure()
     sandbox_dir = sdk.get_directory_structure("sandbox", response_format="PYTHON")
     # TODO: assert here that output.jpg exists in server
     sdk.delete_file(file_path="sandbox/output.jpg")

--- a/Open_LISA_SDK/tests/test_integration_with_server.py
+++ b/Open_LISA_SDK/tests/test_integration_with_server.py
@@ -145,6 +145,19 @@ def test_send_command_to_get_image_from_mock_camera():
         image_bytes = f.read()
         assert image_bytes == result["value"]
 
+def test_send_command_and_save_result_in_server():
+    sdk = SDK(log_level="ERROR")
+    sdk.connect_through_TCP(host=LOCALHOST, port=SERVER_PORT)
+    result = sdk.send_command(instrument_id=MOCK_CAMERA_ID,
+                              command_invocation="get_image", command_result_output_file="sandbox/output.jpg")
+    assert result == None
+    sdk.get_directory_structure()
+    sandbox_dir = sdk.get_directory_structure("sandbox", response_format="PYTHON")
+    # TODO: assert here that output.jpg exists in server
+    sdk.delete_file(file_path="sandbox/output.jpg")
+    sandbox_dir = sdk.get_directory_structure("sandbox", response_format="PYTHON")
+    # TODO: assert here that output.jpg does not exist in server
+
 
 def test_instrument_CRUDs():
     sdk = SDK(log_level="ERROR")


### PR DESCRIPTION
Se agrega un fix en el protocolo: los command result que se guardan en el server no reciben otra respuesta del server esperando el resultado